### PR TITLE
Add Fronter proxy handler

### DIFF
--- a/fronter/Fronter.js
+++ b/fronter/Fronter.js
@@ -1,0 +1,26 @@
+export default async function handler(req, res) {
+  try {
+    const token = process.env.SP_TOKEN;
+    if (!token) {
+      return res.status(500).json({ error: "SP_TOKEN not set" });
+    }
+
+    const upstream = await fetch("https://api.apparyllis.com/v1/fronters/", {
+      headers: { Authorization: token }
+    });
+
+    const text = await upstream.text();
+
+    // Pass through status + content-type; add cache for speed (optional)
+    res
+      .status(upstream.status)
+      .setHeader(
+        "Content-Type",
+        upstream.headers.get("content-type") || "application/json"
+      )
+      .setHeader("Cache-Control", "s-maxage=30, stale-while-revalidate=300")
+      .send(text);
+  } catch (e) {
+    res.status(500).json({ error: "Proxy error", details: String(e) });
+  }
+}


### PR DESCRIPTION
## Summary
- add a Fronter proxy handler for forwarding authenticated requests to the upstream API

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9c8ac0bcc8330a21cb27f11ceee4d