### PR TITLE
Update fronts loader script

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,21 +33,31 @@
       const out = document.getElementById("fronts");
       const meta = document.getElementById("meta");
       try {
-        const res = await fetch("/api/fronters"); // ← call proxy, not SP API
+        const res = await fetch("/api/fronters"); // via your proxy
         if (!res.ok) throw new Error(res.status + " " + res.statusText);
+
         const data = await res.json();
+        console.log(data); // 👈 check console to see raw response
 
         if (!data?.membersFronting?.length) {
           out.textContent = "No one fronting right now.";
-          meta.textContent = data?.lastChange ? ("Last change: " + new Date(data.lastChange).toLocaleString()) : "";
+          if (data?.lastChange) {
+            meta.textContent = "Last change: " + new Date(data.lastChange).toLocaleString();
+          }
           return;
         }
 
         out.innerHTML = data.membersFronting
-          .map(m => `<div class="front">${m.name || m.displayName || "Unnamed"}</div>`)
+          .map(m => `
+        <div class="front" style="border-left: 8px solid ${m.color || "#ddd"};">
+          ${m.displayName || m.name || "Unnamed"}
+        </div>
+      `)
           .join("");
 
-        meta.textContent = data?.lastChange ? ("Last change: " + new Date(data.lastChange).toLocaleString()) : "";
+        if (data?.lastChange) {
+          meta.textContent = "Last change: " + new Date(data.lastChange).toLocaleString();
+        }
       } catch (err) {
         out.textContent = "Error loading fronts.";
         console.error(err);


### PR DESCRIPTION
## Summary
- update the front loading script to log the API response and gracefully handle empty data
- show color-coded borders and display the last change timestamp when available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9caf2b4088330a2fb6cde5280a341