### PR TITLE
Add workflow to update fronts data

### DIFF
--- a/.github/workflows/update-fronts.yml
+++ b/.github/workflows/update-fronts.yml
@@ -1,0 +1,49 @@
+name: Update Fronts
+
+on:
+  schedule:
+    - cron: "*/5 * * * *"      # run about every 5 minutes
+  workflow_dispatch:           # allow manual runs
+  push:
+    paths:
+      - ".github/workflows/update-fronts.yml"   # re-run if you edit this file
+
+jobs:
+  update:
+    permissions:
+      contents: write          # needed to commit fronts.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout site branch
+        uses: actions/checkout@v4
+        with:
+          ref: main            # 👈 change to your Pages branch if not 'main'
+
+      - name: Fetch fronts from SimplyPlural
+        env:
+          SP_TOKEN: ${{ secrets.SP_TOKEN }}
+        run: |
+          set -euo pipefail
+          curl -sS -H "Authorization: $SP_TOKEN" \
+            https://api.apparyllis.com/v1/fronters/ \
+            -o fronts.json
+
+      - name: Validate JSON
+        run: |
+          python - << 'PY'
+          import json
+          json.load(open("fronts.json"))
+          print("fronts.json is valid JSON")
+          PY
+
+      - name: Commit if changed
+        run: |
+          if git diff --quiet fronts.json; then
+            echo "No changes."
+          else
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add fronts.json
+            git commit -m "Update fronts.json [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary
- add a scheduled workflow to fetch the latest fronts data from SimplyPlural
- validate the downloaded JSON and commit updates automatically

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d9cf3939fc83308734ab27280111a6