### PR TITLE
Fix jq block indentation in update-fronts workflow

### DIFF
--- a/.github/workflows/update-fronts.yml
+++ b/.github/workflows/update-fronts.yml
@@ -71,7 +71,9 @@ jobs:
           fi
 
           # lastChange from ms → ISO
-          LAST_CHANGE=$(jq -r '[ .[] | .content.lastOperationTime?, .content.startTime? ] | map(select(.!=null)) | max // empty' "${PAGES_DIR}/fh.json")
+          LAST_CHANGE=$(
+            jq -r '[ .[] | .content.lastOperationTime?, .content.startTime? ] | map(select(.!=null)) | max // empty' "${PAGES_DIR}/fh.json"
+          )
           : "${LAST_CHANGE:=}"
 
           # 3) Get full members list
@@ -93,7 +95,7 @@ jobs:
             --argjson mem "$(cat "${PAGES_DIR}/members.json")" \
             --arg lc "${LAST_CHANGE:-}" \
             --arg WARNING_FIELD "${WARNING_FIELD}" '
-{
+  {
   lastChange: (if $lc=="" then null else (try ($lc|tonumber/1000|todate) catch .) end),
   membersFronting: (
     $fh


### PR DESCRIPTION
## Summary
- indent the jq program body so the workflow script parses as expected

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dab50209bc83309b10780654c3e201