### PR TITLE
Remove overflow clipping from front cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
     .front {
       background:var(--card-bg); border:1px solid var(--border); border-radius:14px; padding:1rem;
       display:grid; grid-template-columns:64px 1fr; grid-template-rows:auto auto auto;
-      gap:.5rem 1rem; align-items:start; overflow:hidden; /* keep content inside */
+      gap:.5rem 1rem; align-items:start;
     }
     .bar { height:6px; background:var(--pill); border-radius:999px; grid-column:1/-1; }
 


### PR DESCRIPTION
## Summary
- remove the overflow clipping rule from `.front` cards so markdown content can display fully

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dac24583bc8330bbbc40e3e1aa3a34